### PR TITLE
Create service.yaml

### DIFF
--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cookie-api-service
+spec:
+  selector:
+    app: cookie-api
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5000
+  type: LoadBalancer


### PR DESCRIPTION
This PR adds a Kubernetes service to expose the cookie API deployment externally via LoadBalancer.